### PR TITLE
Fix code block in usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ To install in a virtual environment in your current project:
 Usage Example
 =============
 
-.. code-block: python3
+.. code-block:: python3
 
     import board
     import busio


### PR DESCRIPTION
Code block was missing a character, causing it not to render in the README